### PR TITLE
Päivitä Checkstyle-versio

### DIFF
--- a/ohjeet/Checkstyle.md
+++ b/ohjeet/Checkstyle.md
@@ -16,7 +16,7 @@ Lisää **pom.xml** tiedostoon
     <plugin>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-checkstyle-plugin</artifactId>
-      <version>2.13</version>
+      <version>2.17</version>
       <configuration>
         <configLocation>checkstyle.xml</configLocation>
       </configuration>
@@ -24,7 +24,7 @@ Lisää **pom.xml** tiedostoon
     <plugin>
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-jxr-plugin</artifactId>
-      <version>2.4</version>
+      <version>2.5</version>
     </plugin>
   </plugins>
 </build>


### PR DESCRIPTION
Kurssilla saa käyttää/suositellaan käyttämään Java 8:aa, mutta ohjeissa suositeltu Checkstyle-versio ei tue sitä, vaan kaatuu ilman selkeää virheilmoitusta kohdatessaan mm. lambdoja ja metodiviitteitä.

Pätsi korjaa virheen päivittämällä jo melko iäkkäästä Checkstyle-pluginin versiosta 2.13 (joka käyttää Checkstyle  5.7:ää) viime lokakuussa julkaistuun versioon 2.17 (joka käyttää Checkstyle 6.11.2:a).
